### PR TITLE
further changes to get to v0.3.0

### DIFF
--- a/2sUNetDA.model.yaml
+++ b/2sUNetDA.model.yaml
@@ -1,3 +1,8 @@
+format_version: 0.3.0
+language: python
+framework: pytorch
+timestamp: 2020-03-29T00:00:00Z
+
 name: Two Steam U-Net DA
 description: Two Steam U-Net trained on brain vasculature segmentation data from Ludovico Silvestri's European Laboratory for Non-linear Spectroscopy (LENS). 
              Two Steam U-Net is used as the segmentation network that takes up the inputs from source and target domain, and generate the respective segmentation results at the output.
@@ -10,16 +15,15 @@ cite:
     - text: "Roger Bermudez et al. A domain-adaptive two-stream U-Net for electron microscopy image segmentation. ISBI 2018."
       doi: https://doi.org/10.1109/ISBI.2018.8363602
 authors:
-  - Roger Bermudez, Vasu Subeesh
+  - Roger Bermudez
+  - Vasu Subeesh
 documentation: documentation/TransferLearningBasedSegmentationWorkflow.md
 tags: [unet2d, pytorch, hbp, sga2, brain, vasculature]
 license: MIT
-
-format_version: 0.1.0
-language: python
-framework: pytorch
+git_repo: https://github.com/subeeshvasu/hdp-DL-sg-codes
 
 source: src.utils.get_2sunet
+dependencies: pip:./reqs.txt
 optional_kwargs:
     steps:                   4
     first_layer_channels:    64
@@ -32,8 +36,8 @@ optional_kwargs:
     layer_sharing_specification: r,r,s,s
     input_is_from_source_domain: False
 
-test_input: tests/data/ipt10.npy
-test_output: tests/data/2sunetda10.npy
+test_input: [tests/data/ipt10.npy]
+test_output: [tests/data/2sunetda10.npy]
 covers: [documentation/covers/2sUNetCover.png]
 
 inputs:
@@ -42,27 +46,25 @@ inputs:
     data_type: float32
     data_range: [0, 1]
     shape: [1, 3, 512, 512]
+    preprocess:
+      - name: scale_range
+        kwargs: {axes: "yx", min_percentile: 0, max_percentile: 100}
+      - name: scale_linear
+        kwargs: {axes: yx, gain: 2.0, offset: -1.0}
 
 outputs:
   - name: probs
     axes: bcyx
     data_type: float32
     data_range: [-inf, inf]
-    halo: [0, 0, 94, 94]
     shape:
       reference_input: raw
       scale: [1, 1, 1, 1]
       offset: [0, 0, 0, 0]
+    halo: [0, 0, 94, 94]
 
-prediction:
-  preprocess:
-    - spec: https://github.com/bioimage-io/pytorch-bioimage-io/blob/b44ff3b99fa2717dd0efea6932b6b07ea1a2b9af/specs/transformations/EnsureNumpy.transformation.yaml
-    - spec: https://github.com/bioimage-io/python-bioimage-io/blob/b44ff3b99fa2717dd0efea6932b6b07ea1a2b9af/specs/transformations/NormalizeRange.transformation.yaml
-      kwargs: {apply_to: 0, output_min: -1.0, output_max: 1.0}
-    - spec: https://github.com/bioimage-io/pytorch-bioimage-io/blob/b44ff3b99fa2717dd0efea6932b6b07ea1a2b9af/specs/transformations/EnsureTorch.transformation.yaml
-  weights:
-      source: https://github.com/subeeshvasu/hbp-DL-seg-codes/releases/download/0.1.1/2sUNetDAweights.pth.tar
-      hash: {sha256: 90d171979cbbef6bd5fb17e1829ef7141c0589ebae9a19bd8edf31a1bcac0bb3}
-  postprocess:
-    - spec: https://github.com/bioimage-io/pytorch-bioimage-io/blob/b44ff3b99fa2717dd0efea6932b6b07ea1a2b9af/specs/transformations/EnsureNumpy.transformation.yaml
-  dependencies: conda:../environment.yaml
+weights:
+  pytorch_state_dict:
+    authors: [Vasu Subeesh]
+    source: https://github.com/subeeshvasu/hbp-DL-seg-codes/releases/download/0.1.1/2sUNetDAweights.pth.tar
+    sha256: 90d171979cbbef6bd5fb17e1829ef7141c0589ebae9a19bd8edf31a1bcac0bb3

--- a/2sUNetDA.model.yaml
+++ b/2sUNetDA.model.yaml
@@ -24,7 +24,7 @@ git_repo: https://github.com/subeeshvasu/hdp-DL-sg-codes
 
 source: src.utils.get_2sunet
 dependencies: pip:./reqs.txt
-optional_kwargs:
+kwargs:
     steps:                   4
     first_layer_channels:    64
     num_classes:             2
@@ -36,8 +36,8 @@ optional_kwargs:
     layer_sharing_specification: r,r,s,s
     input_is_from_source_domain: False
 
-test_input: [tests/data/ipt10.npy]
-test_output: [tests/data/2sunetda10.npy]
+test_inputs: [tests/data/ipt10.npy]
+test_outputs: [tests/data/2sunetda10.npy]
 covers: [documentation/covers/2sUNetCover.png]
 
 inputs:
@@ -46,9 +46,9 @@ inputs:
     data_type: float32
     data_range: [0, 1]
     shape: [1, 3, 512, 512]
-    preprocess:
+    preprocessing:
       - name: scale_range
-        kwargs: {axes: "yx", min_percentile: 0, max_percentile: 100}
+        kwargs: {mode: per_sample, axes: "yx", min_percentile: 0, max_percentile: 100}
       - name: scale_linear
         kwargs: {axes: yx, gain: 2.0, offset: -1.0}
 

--- a/UNetDA.model.yaml
+++ b/UNetDA.model.yaml
@@ -21,7 +21,7 @@ license: MIT
 git_repo: https://github.com/subeeshvasu/hdp-DL-sg-codes
 
 source: src.utils.get_unet
-dependencies: conda:../environment.yaml
+dependencies: pip:./reqs.txt
 kwargs:
   steps:                   4
   first_layer_channels:    64
@@ -43,9 +43,10 @@ inputs:
     data_range: [0, 1]
     shape: [1, 3, 512, 512]
     preprocessing:
-      # NEEDS TO BE UPDATED, no NormalizeRange in spec.
-      - name: https://github.com/bioimage-io/python-bioimage-io/blob/b44ff3b99fa2717dd0efea6932b6b07ea1a2b9af/specs/transformations/NormalizeRange.transformation.yaml
-        kwargs: {apply_to: 0, output_min: -1.0, output_max: 1.0}
+      - name: scale_range
+        kwargs: {mode: per_sample, axes: "yx", min_percentile: 0, max_percentile: 100}
+      - name: scale_linear
+        kwargs: {axes: yx, gain: 2.0, offset: -1.0}
 
 outputs:
   - name: probs

--- a/UNetDA.model.yaml
+++ b/UNetDA.model.yaml
@@ -1,7 +1,7 @@
 format_version: 0.3.0
 language: python
 framework: pytorch
-timestamp: 2015-12-12T01:02:03Z # Need to update this before merge with the real creation date
+timestamp: 2020-03-29T00:00:00Z
 
 name: U-Net DA (Domain Adaptation)
 description: U-Net trained on brain vasculature segmentation data from Ludovico Silvestri's European Laboratory for Non-linear Spectroscopy (LENS). 
@@ -22,15 +22,15 @@ git_repo: https://github.com/subeeshvasu/hdp-DL-sg-codes
 
 source: src.utils.get_unet
 dependencies: conda:../environment.yaml
-optional_kwargs:
-    steps:                   4
-    first_layer_channels:    64
-    num_classes:             2
-    num_input_channels:      3
-    two_sublayers:           True
-    ndims:                   2
-    border_mode:             same
-    remove_skip_connections: False
+kwargs:
+  steps:                   4
+  first_layer_channels:    64
+  num_classes:             2
+  num_input_channels:      3
+  two_sublayers:           True
+  ndims:                   2
+  border_mode:             same
+  remove_skip_connections: False
 
 test_inputs: [tests/data/ipt10.npy]
 test_outputs: [tests/data/unetda10.npy]
@@ -42,6 +42,10 @@ inputs:
     data_type: float32
     data_range: [0, 1]
     shape: [1, 3, 512, 512]
+    preprocessing:
+      # NEEDS TO BE UPDATED, no NormalizeRange in spec.
+      - name: https://github.com/bioimage-io/python-bioimage-io/blob/b44ff3b99fa2717dd0efea6932b6b07ea1a2b9af/specs/transformations/NormalizeRange.transformation.yaml
+        kwargs: {apply_to: 0, output_min: -1.0, output_max: 1.0}
 
 outputs:
   - name: probs
@@ -52,15 +56,12 @@ outputs:
       reference_input: raw
       scale: [1, 1, 1, 1]
       offset: [0, 0, 0, 0]
-      halo: [0, 0, 94, 94]
+    halo: [0, 0, 94, 94]
 
-prediction:
-  preprocess:
-    # NEEDS TO BE UPDATED, no NormalizeRange in spec.
-    - spec: https://github.com/bioimage-io/python-bioimage-io/blob/b44ff3b99fa2717dd0efea6932b6b07ea1a2b9af/specs/transformations/NormalizeRange.transformation.yaml
-      kwargs: {apply_to: 0, output_min: -1.0, output_max: 1.0}
-    - spec: https://github.com/bioimage-io/pytorch-bioimage-io/blob/b44ff3b99fa2717dd0efea6932b6b07ea1a2b9af/specs/transformations/EnsureTorch.transformation.yaml
-  weights:
-      source: https://github.com/subeeshvasu/hbp-DL-seg-codes/releases/download/0.1.1/UNetDAweights.pth.tar
-      hash: {sha256: 90d171979cbbef6bd5fb17e1829ef7141c0589ebae9a19bd8edf31a1bcac0bb3}
+weights:
+  pytorch_state_dict:
+    authors: [Vasu Subeesh]
+    source: https://github.com/subeeshvasu/hbp-DL-seg-codes/releases/download/0.1.1/UNetDAweights.pth.tar
+    sha256: 90d171979cbbef6bd5fb17e1829ef7141c0589ebae9a19bd8edf31a1bcac0bb3
+
   


### PR DESCRIPTION
Questions/Todos:

- [x] what would be the original creation date for this model @subeeshvasu?
- [x] is `EnsureNumpy`, and `EnsureTorch` a thing of the past? I removed it as it's not in spec.
- [x] it seems that there is no equivalent of `NormalizeRange` in the trasnsformation spec? Also I don't see a combination of supported preprocessing steps, that would generate the same result. Or maybe I misunderstand what `scale_range` is doing. It's saying percentile normalization (e.g. [here](https://github.com/seangibbons/percentile_normalization). Alternatively, if it would "normalize" data by applying linear scaling such that the lower percentile ends up at 0, and the high percentile ends up at 1, then, of course one could do
  ```yaml    preprocessing:
      - name: scale_range
        kwargs: {axes: "zyx", min_percentile: 0, max_percentile: 100}
      - name: scale_linear
        kwargs: {gain: 2.0, offset: -1.0}
  ```
CC: @FynnBe